### PR TITLE
Added batch_cmd and meshing counters

### DIFF
--- a/src/world/mod.rs
+++ b/src/world/mod.rs
@@ -3,7 +3,7 @@ use bevy::prelude::*;
 mod debug;
 mod math;
 mod mesh;
-mod pipeline;
+pub mod pipeline;
 
 pub mod query;
 pub mod storage;

--- a/src/world/pipeline/mod.rs
+++ b/src/world/pipeline/mod.rs
@@ -21,6 +21,9 @@ mod landscaping;
 mod rendering;
 mod terraforming;
 
+pub use rendering::MeshGenerationCounter;
+
+pub use genesis::BatchChunkCmdRes;
 pub use genesis::{EvtChunkLoaded, EvtChunkUnloaded, EvtChunkUpdated, WorldRes};
 pub use landscaping::LandscapeConfig;
 pub use terraforming::{ChunkSystemQuery, ChunkSystemRaycast, CmdChunkUpdate, RaycastResult};

--- a/src/world/pipeline/rendering.rs
+++ b/src/world/pipeline/rendering.rs
@@ -95,6 +95,11 @@ struct MeshGenerationMeta {
     batch_id: usize,
 }
 
+#[derive(Default)]
+pub struct MeshGenerationCounter {
+    pub task_counter: usize,
+}
+
 const MESH_BATCH_SIZE: usize = landscape::HORIZONTAL_SIZE * landscape::HORIZONTAL_SIZE;
 
 fn mesh_generation_system(
@@ -105,6 +110,7 @@ fn mesh_generation_system(
     task_pool: Res<AsyncComputeTaskPool>,
     mut meta: Local<MeshGenerationMeta>,
     mut reader: EventReader<EvtChunkMeshDirty>,
+    counter: Option<ResMut<MeshGenerationCounter>>,
 ) {
     let mut _perf = perf_fn!();
 
@@ -148,6 +154,14 @@ fn mesh_generation_system(
         }
 
         meta.tasks.remove(&batch_id);
+    }
+
+    if let Some(mut counter) = counter {
+        counter.task_counter = meta.tasks.len();
+    } else {
+        commands.insert_resource(MeshGenerationCounter {
+            task_counter: meta.tasks.len(),
+        });
     }
 }
 
@@ -198,7 +212,6 @@ fn generate_mesh(
         mesh.insert_attribute(Mesh::ATTRIBUTE_POSITION, positions);
         mesh.insert_attribute(Mesh::ATTRIBUTE_NORMAL, normals);
         mesh.insert_attribute(Mesh::ATTRIBUTE_UV_0, vec![0; vertex_count]);
-
 
         commands.entity(entity).insert(meshes.add(mesh));
     }

--- a/src/world/storage/landscape.rs
+++ b/src/world/storage/landscape.rs
@@ -1,5 +1,5 @@
 pub const HORIZONTAL_SIZE: usize = 16;
-pub const VERTICAL_SIZE: usize = 32;
+pub const VERTICAL_SIZE: usize = 16;
 
 pub const HORIZONTAL_BEGIN: i32 = -(HORIZONTAL_SIZE as i32) / 2;
 pub const HORIZONTAL_END: i32 = HORIZONTAL_BEGIN + HORIZONTAL_SIZE as i32;


### PR DESCRIPTION
Added BatchChunkCmd and Meshing counters on the screen.

It was possible to visualize that most of the time is spent on genesis batching,  probably due to IO and time spent on empty chunks as reported on #13 

Fixes #15 