### PR TITLE
Added compression/decompression on chunk cache generation

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,6 +14,7 @@ serde = "1.0.130"
 bincode = "1.3.3"
 futures-lite = "1.12.0"
 bevy_egui = "0.14.0"
+lz4_flex = "0.9.3"
 
 # Used by perf_counter
 once_cell = {version = "1.8.0", optional = true}


### PR DESCRIPTION
Added compression/decompression using library https://github.com/pseitz/lz4_flex

Closes #13 

Here are some benchmarking tests:

### Without Compression ###
Clean run (full generation) | chunk 16³ | landscape 16³: ***27.35s***
Normal run (existing cache) | chunk 16³ | landscape 16³: ***11.89s***

### With Compression ###
Clean run (full generation) | chunk 16³ | landscape 16³: ***3.22s***
Normal run (existing cache) | chunk 16³ | landscape 16³: ***2.69s***

So we have a considerable reduction. I think it's possible to have even better time reduction. but when walking on normal speed, the time used to generate a new line of chunks (16²) is about 0.5s, so the next bottle neck is the mesh generation, which should be addressed in another PR.