### PR TITLE
Filtered empty chunks to not be sent to meshing worker

### DIFF
--- a/src/world/pipeline/rendering.rs
+++ b/src/world/pipeline/rendering.rs
@@ -117,6 +117,7 @@ fn mesh_generation_system(
     let chunks = reader
         .iter()
         .filter_map(|evt| vox_world.get(evt.0).map(|c| (evt.0, c)))
+        .filter(|(_, c)| !c.is_empty())
         .collect::<Vec<_>>();
 
     for batch in chunks.chunks(MESH_BATCH_SIZE) {

--- a/src/world/storage/chunk.rs
+++ b/src/world/storage/chunk.rs
@@ -299,7 +299,7 @@ impl<T: ChunkStorageType> ChunkNeighborhood<T> {
     fn to_index(side: voxel::Side, pos: IVec3) -> usize {
         use voxel::Side;
 
-        assert!(match &side {
+        debug_assert!(match &side {
             Side::Right => pos.x == 0,
             Side::Left => pos.x == X_END as i32,
             Side::Up => pos.y == 0,

--- a/src/world/storage/chunk.rs
+++ b/src/world/storage/chunk.rs
@@ -8,9 +8,9 @@ use crate::world::{math, query, storage::chunk};
 
 use super::voxel;
 
-pub const X_AXIS_SIZE: usize = 16;
-pub const Z_AXIS_SIZE: usize = 16;
-pub const Y_AXIS_SIZE: usize = 16;
+pub const X_AXIS_SIZE: usize = 32;
+pub const Z_AXIS_SIZE: usize = 32;
+pub const Y_AXIS_SIZE: usize = 32;
 
 pub const X_END: i32 = (X_AXIS_SIZE - 1) as i32;
 pub const Z_END: i32 = (Z_AXIS_SIZE - 1) as i32;
@@ -123,7 +123,6 @@ impl<T: ChunkStorageType> ChunkStorage<T> {
         self.is_all(T::default())
     }
 
-    #[cfg(test)]
     pub fn is_all(&self, value: T) -> bool {
         self.iter().all(|t| *t == value)
     }
@@ -191,6 +190,12 @@ impl<T: ChunkStorageType> Drop for ChunkStorage<T> {
 }
 
 pub type ChunkKind = ChunkStorage<voxel::Kind>;
+
+impl ChunkKind {
+    pub fn is_empty(&self) -> bool {
+        self.is_all(0u16.into())
+    }
+}
 
 pub fn to_index(local: IVec3) -> usize {
     (local.x << X_SHIFT | local.y << Y_SHIFT | local.z << Z_SHIFT) as usize

--- a/src/world/storage/landscape.rs
+++ b/src/world/storage/landscape.rs
@@ -1,5 +1,5 @@
-pub const HORIZONTAL_SIZE: usize = 16;
-pub const VERTICAL_SIZE: usize = 16;
+pub const HORIZONTAL_SIZE: usize = 8;
+pub const VERTICAL_SIZE: usize = 8;
 
 pub const HORIZONTAL_BEGIN: i32 = -(HORIZONTAL_SIZE as i32) / 2;
 pub const HORIZONTAL_END: i32 = HORIZONTAL_BEGIN + HORIZONTAL_SIZE as i32;


### PR DESCRIPTION
Currently the mesh generation for 32³ chunks on a 8³ landscape takes 13s. This PR tries to reduces this time.