### PR TITLE
Improve memory allocation of ChunkStorage

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -34,7 +34,7 @@ jobs:
       - name: Install nightly toolchain
         uses: dtolnay/rust-toolchain@nightly
       - name: Install Dependencies
-        run: sudo apt-get update; sudo apt-get install --no-install-recommends libasound2-dev libudev-dev
+        run: sudo apt-get update; sudo apt-get install --no-install-recommends libasound2-dev libudev-dev libwayland-dev libxkbcommon-dev
       - name: Run cargo test
         run: cargo test --workspace
 
@@ -63,7 +63,7 @@ jobs:
         with:
           components: clippy
       - name: Install Dependencies
-        run: sudo apt-get update; sudo apt-get install --no-install-recommends libasound2-dev libudev-dev
+        run: sudo apt-get update; sudo apt-get install --no-install-recommends libasound2-dev libudev-dev libwayland-dev libxkbcommon-dev
       - name: Run clippy
         run: cargo clippy -- -D warnings
 

--- a/.gitignore
+++ b/.gitignore
@@ -25,4 +25,4 @@ world/
 chunks/
 
 heaptrack.*
-rust-ice*
+rustc-ice*

--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,6 @@ cache/
 tracy/
 world/
 chunks/
+
+heaptrack.*
+rust-ice*

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -65,7 +65,6 @@ unused_extern_crates = "warn"
 workspace = true
 
 [profile.dev.package."*"]
-hint-mostly-unused = true
 opt-level = 3
 
 [[example]]

--- a/crates/client/Cargo.toml
+++ b/crates/client/Cargo.toml
@@ -2,6 +2,7 @@
 name = "projekto_client"
 version = "0.1.0"
 edition = "2021"
+default-run = "client"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
@@ -9,6 +10,7 @@ edition = "2021"
 default = [
     "dev",
     "bevy/tonemapping_luts",
+    "bevy/wayland",
 ]
 
 dev = [
@@ -28,3 +30,7 @@ futures-lite.workspace = true
 
 [lints]
 workspace = true
+
+[[bin]]
+name = "client"
+path = "src/main.rs"

--- a/crates/core/Cargo.toml
+++ b/crates/core/Cargo.toml
@@ -9,8 +9,8 @@ readme = "README.md"
 bevy.workspace = true
 serde.workspace = true
 
-once_cell = "1.19"
-ron = "0.8"
+once_cell = "1.21"
+ron = "0.10"
 
 [dev-dependencies]
 rand.workspace = true

--- a/crates/core/Cargo.toml
+++ b/crates/core/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "projekto_core"
 version = "0.1.0"
-edition = "2021"
+edition = "2024"
 license = "MIT"
 readme = "README.md"
 

--- a/crates/core/src/chunk/mod.rs
+++ b/crates/core/src/chunk/mod.rs
@@ -8,6 +8,8 @@ use serde::{Deserialize, Serialize};
 mod storage;
 pub use storage::*;
 
+mod sub_chunk;
+
 pub const X_AXIS_SIZE: usize = 16;
 pub const Y_AXIS_SIZE: usize = 256;
 pub const Z_AXIS_SIZE: usize = 16;

--- a/crates/core/src/chunk/mod.rs
+++ b/crates/core/src/chunk/mod.rs
@@ -5,6 +5,9 @@ use crate::{
 use bevy::math::{IVec2, IVec3, Vec3};
 use serde::{Deserialize, Serialize};
 
+mod storage;
+pub use storage::*;
+
 pub const X_AXIS_SIZE: usize = 16;
 pub const Y_AXIS_SIZE: usize = 256;
 pub const Z_AXIS_SIZE: usize = 16;
@@ -175,151 +178,6 @@ impl ChunkSide {
             voxel::Side::Back => Some(Self::Back),
             _ => None,
         }
-    }
-}
-
-pub trait ChunkStorageType:
-    Clone + Copy + core::fmt::Debug + Default + PartialEq + PartialOrd
-{
-}
-
-impl ChunkStorageType for u8 {}
-impl ChunkStorageType for voxel::Kind {}
-impl ChunkStorageType for voxel::Light {}
-impl ChunkStorageType for voxel::FacesOcclusion {}
-impl ChunkStorageType for voxel::FacesSoftLight {}
-
-#[derive(Clone, Serialize, Deserialize, PartialEq, PartialOrd)]
-enum StorageValue<T> {
-    Single(T),
-    Multiple(Vec<T>),
-}
-
-impl<T: ChunkStorageType> StorageValue<T> {
-    fn as_multiple(&mut self) {
-        match self {
-            StorageValue::Single(t) => {
-                let t = *t;
-                let _ = std::mem::replace(self, StorageValue::Multiple(vec![t; BUFFER_SIZE]));
-            }
-            StorageValue::Multiple(_) => (),
-        }
-    }
-}
-
-#[derive(Clone, Serialize, Deserialize)]
-pub struct ChunkStorage<T>(StorageValue<T>);
-
-impl<T: ChunkStorageType> PartialEq for ChunkStorage<T> {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-
-impl<T: ChunkStorageType> std::fmt::Debug for ChunkStorage<T> {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        let len = match &self.0 {
-            StorageValue::Single(_) => 0,
-            StorageValue::Multiple(buf) => buf.len(),
-        };
-        write!(f, "ChunkStorage(len: {len})")
-    }
-}
-
-impl<T: ChunkStorageType> std::default::Default for ChunkStorage<T> {
-    fn default() -> Self {
-        Self(StorageValue::Single(T::default()))
-    }
-}
-
-impl<T: ChunkStorageType> ChunkStorage<T> {
-    pub fn get(&self, voxel: Voxel) -> T {
-        match &self.0 {
-            StorageValue::Multiple(b) => b[to_index(voxel)],
-            StorageValue::Single(t) => *t,
-        }
-    }
-
-    pub fn set(&mut self, voxel: Voxel, value: T) {
-        match &mut self.0 {
-            StorageValue::Single(v) if *v != value => {
-                self.0.as_multiple();
-                self.set(voxel, value);
-            }
-            StorageValue::Multiple(items) => items[to_index(voxel)] = value,
-            _ => (),
-        }
-    }
-
-    pub fn is_default(&self) -> bool {
-        matches!(self.0, StorageValue::Single(_))
-    }
-
-    pub fn all<F>(&self, mut f: F) -> bool
-    where
-        F: FnMut(&T) -> bool,
-    {
-        match &self.0 {
-            StorageValue::Multiple(buf) => buf.iter().all(f),
-            StorageValue::Single(t) => f(t),
-        }
-    }
-}
-impl<T: ChunkStorageType> std::ops::Index<usize> for ChunkStorage<T> {
-    type Output = T;
-
-    fn index(&self, index: usize) -> &Self::Output {
-        debug_assert!(index < BUFFER_SIZE);
-        match &self.0 {
-            StorageValue::Multiple(buf) => &buf[index],
-            StorageValue::Single(t) => t,
-        }
-    }
-}
-
-impl<T: ChunkStorageType> std::ops::IndexMut<usize> for ChunkStorage<T> {
-    fn index_mut(&mut self, index: usize) -> &mut Self::Output {
-        debug_assert!(index < BUFFER_SIZE);
-
-        // Had to do this to avoid the borrow checker yelling at me
-        if matches!(self.0, StorageValue::Multiple(_)) {
-            if let StorageValue::Multiple(items) = &mut self.0 {
-                &mut items[index]
-            } else {
-                unreachable!()
-            }
-        } else {
-            self.0.as_multiple();
-            self.index_mut(index)
-        }
-    }
-}
-
-pub trait GetChunkStorage<'a, T: ChunkStorageType + 'a>:
-    Fn(Chunk) -> Option<&'a ChunkStorage<T>> + Copy
-{
-}
-
-impl<'a, T: ChunkStorageType + 'a, F: Copy> GetChunkStorage<'a, T> for F where
-    F: Fn(Chunk) -> Option<&'a ChunkStorage<T>>
-{
-}
-
-pub trait GetChunkStorageMut<'a, T: ChunkStorageType + 'a>:
-    FnMut(Chunk) -> Option<&'a mut ChunkStorage<T>> + Copy
-{
-}
-
-impl<'a, T: ChunkStorageType + 'a, F: Copy> GetChunkStorageMut<'a, T> for F where
-    F: FnMut(Chunk) -> Option<&'a mut ChunkStorage<T>>
-{
-}
-
-impl ChunkStorage<voxel::Light> {
-    pub fn set_type(&mut self, voxel: Voxel, ty: voxel::LightTy, intensity: u8) {
-        let mut light = self.get(voxel);
-        light.set(ty, intensity);
-        self.set(voxel, light);
     }
 }
 

--- a/crates/core/src/chunk/storage.rs
+++ b/crates/core/src/chunk/storage.rs
@@ -23,7 +23,7 @@ const X_MASK: usize = (SUB_CHUNKS_X - 1) << X_SHIFT;
 const Z_MASK: usize = (SUB_CHUNKS_Z - 1) << Z_SHIFT;
 const Y_MASK: usize = SUB_CHUNKS_Y - 1;
 
-#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+#[derive(Clone, PartialEq, Serialize, Deserialize)]
 struct SubChunkStorage<T>(Vec<ChunkPack<T>>);
 
 impl<T> SubChunkStorage<T> {
@@ -77,8 +77,24 @@ impl ChunkStorageType for voxel::Light {}
 impl ChunkStorageType for voxel::FacesOcclusion {}
 impl ChunkStorageType for voxel::FacesSoftLight {}
 
-#[derive(Clone, Debug, Serialize, Deserialize)]
+#[derive(Clone, Serialize, Deserialize)]
 pub struct ChunkStorage<T>(SubChunkStorage<T>);
+
+impl<T: ChunkStorageType> std::fmt::Debug for ChunkStorage<T> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let mut s_cnt = 0;
+        let mut p_cnt = 0;
+        let mut d_cnt = 0;
+        for pack in &self.0.0 {
+            match pack {
+                ChunkPack::Single(_) => s_cnt += 1,
+                ChunkPack::Pallet { .. } => p_cnt += 1,
+                ChunkPack::Dense(_) => d_cnt += 1,
+            }
+        }
+        f.write_fmt(format_args!("S: {s_cnt}, P: {p_cnt}, D: {d_cnt}"))
+    }
+}
 
 impl<T: ChunkStorageType> PartialEq for ChunkStorage<T> {
     fn eq(&self, other: &Self) -> bool {

--- a/crates/core/src/chunk/storage.rs
+++ b/crates/core/src/chunk/storage.rs
@@ -1,0 +1,152 @@
+use bevy::prelude::*;
+use serde::{Deserialize, Serialize};
+
+use crate::{
+    chunk::{self, Chunk, BUFFER_SIZE},
+    voxel::{self, Voxel},
+};
+
+pub trait ChunkStorageType:
+    Clone + Copy + core::fmt::Debug + Default + PartialEq + Eq + PartialOrd + std::hash::Hash
+{
+}
+
+impl ChunkStorageType for u8 {}
+impl ChunkStorageType for voxel::Kind {}
+impl ChunkStorageType for voxel::Light {}
+impl ChunkStorageType for voxel::FacesOcclusion {}
+impl ChunkStorageType for voxel::FacesSoftLight {}
+
+#[derive(Clone, Serialize, Deserialize, PartialEq, PartialOrd)]
+enum StorageValue<T> {
+    Single(T),
+    Dense(Vec<T>),
+}
+
+impl<T: ChunkStorageType> StorageValue<T> {
+    fn as_multiple(&mut self) {
+        match self {
+            StorageValue::Single(t) => {
+                let t = *t;
+                let _ = std::mem::replace(self, StorageValue::Dense(vec![t; BUFFER_SIZE]));
+            }
+            StorageValue::Dense(_) => (),
+        }
+    }
+}
+
+#[derive(Clone, Serialize, Deserialize)]
+pub struct ChunkStorage<T>(StorageValue<T>);
+
+impl<T: ChunkStorageType> PartialEq for ChunkStorage<T> {
+    fn eq(&self, other: &Self) -> bool {
+        self.0 == other.0
+    }
+}
+
+impl<T: ChunkStorageType> std::fmt::Debug for ChunkStorage<T> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let len = match &self.0 {
+            StorageValue::Single(_) => 0,
+            StorageValue::Dense(buf) => buf.len(),
+        };
+        write!(f, "ChunkStorage(len: {len})")
+    }
+}
+
+impl<T: ChunkStorageType> std::default::Default for ChunkStorage<T> {
+    fn default() -> Self {
+        Self(StorageValue::Single(T::default()))
+    }
+}
+
+impl<T: ChunkStorageType> ChunkStorage<T> {
+    pub fn get(&self, voxel: Voxel) -> T {
+        match &self.0 {
+            StorageValue::Dense(b) => b[chunk::to_index(voxel)],
+            StorageValue::Single(t) => *t,
+        }
+    }
+
+    pub fn set(&mut self, voxel: Voxel, value: T) {
+        match &mut self.0 {
+            StorageValue::Single(v) if *v != value => {
+                self.0.as_multiple();
+                self.set(voxel, value);
+            }
+            StorageValue::Dense(items) => items[chunk::to_index(voxel)] = value,
+            _ => (),
+        }
+    }
+
+    pub fn is_default(&self) -> bool {
+        matches!(self.0, StorageValue::Single(_))
+    }
+
+    pub fn all<F>(&self, mut f: F) -> bool
+    where
+        F: FnMut(&T) -> bool,
+    {
+        match &self.0 {
+            StorageValue::Dense(buf) => buf.iter().all(f),
+            StorageValue::Single(t) => f(t),
+        }
+    }
+}
+impl<T: ChunkStorageType> std::ops::Index<usize> for ChunkStorage<T> {
+    type Output = T;
+
+    fn index(&self, index: usize) -> &Self::Output {
+        debug_assert!(index < BUFFER_SIZE);
+        match &self.0 {
+            StorageValue::Dense(buf) => &buf[index],
+            StorageValue::Single(t) => t,
+        }
+    }
+}
+
+impl<T: ChunkStorageType> std::ops::IndexMut<usize> for ChunkStorage<T> {
+    fn index_mut(&mut self, index: usize) -> &mut Self::Output {
+        debug_assert!(index < BUFFER_SIZE);
+
+        // Had to do this to avoid the borrow checker yelling at me
+        if matches!(self.0, StorageValue::Dense(_)) {
+            if let StorageValue::Dense(items) = &mut self.0 {
+                &mut items[index]
+            } else {
+                unreachable!()
+            }
+        } else {
+            self.0.as_multiple();
+            self.index_mut(index)
+        }
+    }
+}
+
+pub trait GetChunkStorage<'a, T: ChunkStorageType + 'a>:
+    Fn(Chunk) -> Option<&'a ChunkStorage<T>> + Copy
+{
+}
+
+impl<'a, T: ChunkStorageType + 'a, F: Copy> GetChunkStorage<'a, T> for F where
+    F: Fn(Chunk) -> Option<&'a ChunkStorage<T>>
+{
+}
+
+pub trait GetChunkStorageMut<'a, T: ChunkStorageType + 'a>:
+    FnMut(Chunk) -> Option<&'a mut ChunkStorage<T>> + Copy
+{
+}
+
+impl<'a, T: ChunkStorageType + 'a, F: Copy> GetChunkStorageMut<'a, T> for F where
+    F: FnMut(Chunk) -> Option<&'a mut ChunkStorage<T>>
+{
+}
+
+impl ChunkStorage<voxel::Light> {
+    pub fn set_type(&mut self, voxel: Voxel, ty: voxel::LightTy, intensity: u8) {
+        let mut light = self.get(voxel);
+        light.set(ty, intensity);
+        self.set(voxel, light);
+    }
+}

--- a/crates/core/src/chunk/sub_chunk.rs
+++ b/crates/core/src/chunk/sub_chunk.rs
@@ -1,0 +1,640 @@
+#![allow(unused)]
+use std::ops::{Deref, DerefMut};
+
+use bevy::{
+    math::Vec3,
+    platform::collections::HashSet,
+    prelude::{Deref, DerefMut},
+};
+use serde::{Deserialize, Serialize};
+
+use crate::{
+    chunk::ChunkStorageType,
+    voxel::{self, FacesOcclusion, FacesSoftLight, Kind, Light, LightTy, Voxel},
+};
+
+pub const X_AXIS_SIZE: usize = 8;
+pub const Y_AXIS_SIZE: usize = 8;
+pub const Z_AXIS_SIZE: usize = 8;
+
+pub const X_END: i32 = (X_AXIS_SIZE - 1) as i32;
+pub const Y_END: i32 = (Y_AXIS_SIZE - 1) as i32;
+pub const Z_END: i32 = (Z_AXIS_SIZE - 1) as i32;
+
+pub const BUFFER_SIZE: usize = X_AXIS_SIZE * Z_AXIS_SIZE * Y_AXIS_SIZE;
+
+const X_SHIFT: usize = (Z_AXIS_SIZE.ilog2() + Z_SHIFT as u32) as usize;
+const Z_SHIFT: usize = Y_AXIS_SIZE.ilog2() as usize;
+const Y_SHIFT: usize = 0;
+
+const X_MASK: usize = (X_AXIS_SIZE - 1) << X_SHIFT;
+const Z_MASK: usize = (Z_AXIS_SIZE - 1) << Z_SHIFT;
+const Y_MASK: usize = Y_AXIS_SIZE - 1;
+
+#[inline]
+pub fn to_index(voxel: Voxel) -> usize {
+    (voxel.x << X_SHIFT | voxel.y << Y_SHIFT | voxel.z << Z_SHIFT) as usize
+}
+
+#[inline]
+pub fn from_index(index: usize) -> Voxel {
+    Voxel::new(
+        ((index & X_MASK) >> X_SHIFT) as i32,
+        ((index & Y_MASK) >> Y_SHIFT) as i32,
+        ((index & Z_MASK) >> Z_SHIFT) as i32,
+    )
+}
+
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+struct VoxelStatePallet<T> {
+    pallet: Vec<T>,
+    dirty: bool,
+}
+
+impl<T> VoxelStatePallet<T>
+where
+    T: ChunkStorageType,
+{
+    fn new(pallet: Vec<T>) -> Self {
+        Self {
+            pallet,
+            dirty: false,
+        }
+    }
+
+    fn empty() -> Self {
+        Self {
+            pallet: vec![],
+            dirty: false,
+        }
+    }
+
+    fn find_or_add(&mut self, value: T) -> u8 {
+        if let Some(index) = self.pallet.iter().position(|s| *s == value) {
+            index as u8
+        } else {
+            self.pallet.push(value);
+            self.dirty = true;
+            (self.pallet.len() - 1) as u8
+        }
+    }
+}
+
+impl<T> Default for VoxelStatePallet<T>
+where
+    T: Default,
+{
+    fn default() -> Self {
+        Self {
+            pallet: vec![Default::default()],
+            dirty: Default::default(),
+        }
+    }
+}
+
+impl<T> Deref for VoxelStatePallet<T> {
+    type Target = Vec<T>;
+
+    fn deref(&self) -> &Self::Target {
+        &self.pallet
+    }
+}
+
+#[derive(Clone, Debug, PartialEq, Deref, DerefMut, Serialize, Deserialize)]
+#[repr(transparent)]
+pub(crate) struct PackIndices(pub(crate) Vec<u8>);
+
+#[derive(Clone, Debug, PartialEq, Deref, DerefMut, Serialize, Deserialize)]
+#[repr(transparent)]
+pub(crate) struct DenseBuffer<T>(pub(crate) Vec<T>);
+
+#[allow(private_interfaces)]
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+pub(crate) enum ChunkPack<T> {
+    Single(T),
+    Pallet {
+        pallet: VoxelStatePallet<T>,
+        indices: PackIndices,
+    },
+    Dense(DenseBuffer<T>),
+}
+
+impl<T> Default for ChunkPack<T>
+where
+    T: Default,
+{
+    fn default() -> Self {
+        ChunkPack::Single(Default::default())
+    }
+}
+
+impl<T> ChunkPack<T>
+where
+    T: ChunkStorageType,
+{
+    fn new_pallet() -> Self {
+        Self::Pallet {
+            pallet: VoxelStatePallet::default(),
+            indices: PackIndices(vec![0; BUFFER_SIZE]),
+        }
+    }
+
+    #[inline]
+    fn take(&mut self) -> ChunkPack<T> {
+        std::mem::take(self)
+    }
+
+    #[inline]
+    fn replace(&mut self, mut new: ChunkPack<T>) -> ChunkPack<T> {
+        std::mem::replace(self, new)
+    }
+
+    pub(crate) fn get(&self, voxel: Voxel) -> T {
+        match &self {
+            ChunkPack::Single(value) => *value,
+            ChunkPack::Pallet { pallet, indices } => pallet[indices[to_index(voxel)] as usize],
+            ChunkPack::Dense(voxels) => voxels[to_index(voxel)],
+        }
+    }
+
+    pub(crate) fn set(&mut self, voxel: Voxel, value: T) {
+        if let ChunkPack::Single(current) = self
+            && *current == value
+        {
+            // nothing to do here
+            return;
+        }
+
+        let new_value = match self.take() {
+            ChunkPack::Single(voxel_value) => single_to_pallet(voxel_value, voxel, value),
+            ChunkPack::Pallet {
+                mut pallet,
+                mut indices,
+            } => {
+                if pallet.len() < u8::MAX as usize || pallet_clean_up(&mut pallet, &mut indices) {
+                    let pallet_index = pallet.find_or_add(value);
+                    indices[to_index(voxel)] = pallet_index;
+                    ChunkPack::Pallet { pallet, indices }
+                } else {
+                    let mut dense = pallet_to_dense(pallet, indices);
+                    dense.set(voxel, value);
+                    dense
+                }
+            }
+            ChunkPack::Dense(mut voxels) => {
+                voxels[to_index(voxel)] = value;
+                ChunkPack::Dense(voxels)
+            }
+        };
+        self.replace(new_value);
+    }
+
+    fn pack(&mut self) {
+        if matches!(self, ChunkPack::Single(_)) {
+            // nothing to do there
+            return;
+        }
+
+        let new_value = match self.take() {
+            ChunkPack::Pallet {
+                mut pallet,
+                mut indices,
+            } => {
+                pallet_clean_up(&mut pallet, &mut indices);
+
+                if pallet.len() == 1 {
+                    ChunkPack::Single(pallet[0])
+                } else {
+                    ChunkPack::Pallet { pallet, indices }
+                }
+            }
+            ChunkPack::Dense(voxels) => {
+                let uniques = voxels.iter().collect::<HashSet<_>>().len();
+
+                assert!(uniques > 0, "There always be at least 1 unique value");
+
+                if uniques == 1 {
+                    ChunkPack::Single(voxels[0])
+                } else if uniques <= u8::MAX as usize {
+                    dense_to_pallet(voxels)
+                } else {
+                    ChunkPack::Dense(voxels)
+                }
+            }
+            _ => unreachable!(),
+        };
+
+        self.replace(new_value);
+    }
+
+    pub(crate) fn all<F>(&self, mut f: F) -> bool
+    where
+        F: FnMut(&T) -> bool,
+    {
+        match self {
+            ChunkPack::Single(v) => f(v),
+            ChunkPack::Pallet { pallet, .. } => pallet.iter().all(f),
+            ChunkPack::Dense(dense_buffer) => dense_buffer.iter().all(f),
+        }
+    }
+}
+
+fn single_to_pallet<T>(single: T, new_voxel: Voxel, new_value: T) -> ChunkPack<T>
+where
+    T: ChunkStorageType,
+{
+    // init indices point to existing voxel state on pallet
+    let mut indices = PackIndices(vec![0; BUFFER_SIZE]);
+
+    // the new voxel state voxel and the second on the pallet
+    indices[to_index(new_voxel)] = 1;
+    ChunkPack::Pallet {
+        pallet: VoxelStatePallet::new(vec![single, new_value]),
+        indices,
+    }
+}
+
+fn pallet_clean_up<T>(pallet: &mut VoxelStatePallet<T>, indices: &mut [u8]) -> bool
+where
+    T: ChunkStorageType,
+{
+    if !pallet.dirty {
+        return false;
+    }
+    pallet.dirty = false;
+
+    let mut new_indices = [0u8; BUFFER_SIZE];
+    let mut new_pallet = VoxelStatePallet::empty();
+
+    for i in 0..BUFFER_SIZE {
+        let new_idx = new_pallet.find_or_add(pallet[indices[i] as usize]);
+        new_indices[i] = new_idx;
+    }
+
+    if new_pallet.len() < pallet.len() {
+        std::mem::swap(pallet, &mut new_pallet);
+        indices.copy_from_slice(&new_indices);
+        true
+    } else {
+        false
+    }
+}
+
+fn pallet_to_dense<T>(pallet: VoxelStatePallet<T>, indices: PackIndices) -> ChunkPack<T>
+where
+    T: ChunkStorageType,
+{
+    let mut voxels = DenseBuffer(vec![Default::default(); BUFFER_SIZE]);
+
+    for i in 0..BUFFER_SIZE {
+        voxels[i] = pallet[indices[i] as usize];
+    }
+
+    ChunkPack::Dense(voxels)
+}
+
+fn dense_to_pallet<T>(voxels: DenseBuffer<T>) -> ChunkPack<T>
+where
+    T: ChunkStorageType,
+{
+    let mut pallet = VoxelStatePallet::empty();
+
+    let mut indices = PackIndices(vec![0; BUFFER_SIZE]);
+
+    voxels.iter().enumerate().for_each(|(i, value)| {
+        let pallet_index = pallet.find_or_add(*value);
+        indices[i] = pallet_index;
+    });
+
+    ChunkPack::Pallet { pallet, indices }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn single_get() {
+        // Arrange
+        let state = 1u8;
+        let single = ChunkPack::Single(state);
+
+        // Act
+        let value = single.get(Voxel::new(0, 1, 2));
+
+        // Assert
+        assert_eq!(value, state);
+    }
+
+    #[test]
+    fn single_set_same() {
+        // Arrange
+        let state = 1u8;
+        let mut single = ChunkPack::Single(state);
+
+        // Act
+        single.set(Voxel::new(1, 2, 3), state);
+
+        // Assert
+        assert!(matches!(single, ChunkPack::Single(_)));
+        assert_eq!(single.get(Voxel::new(0, 1, 2)), state);
+    }
+
+    #[test]
+    fn single_set_diff() {
+        // Arrange
+        let state = 10u8;
+        let diff_state = 2u8;
+        let mut chunk = ChunkPack::Single(state);
+
+        // Act
+        chunk.set(Voxel::new(1, 2, 3), diff_state);
+
+        // Assert
+        assert!(matches!(chunk, ChunkPack::Pallet { .. }));
+
+        let new_state = chunk.get(Voxel::new(1, 2, 3));
+        assert_eq!(new_state, diff_state);
+
+        let existing_state = chunk.get(Voxel::new(5, 1, 5));
+        assert_eq!(existing_state, state);
+    }
+
+    #[test]
+    fn pallet_get_set_unique() {
+        // Arrange
+        let mut pallet = ChunkPack::new_pallet();
+
+        let voxels = [
+            Voxel::new(1, 2, 3),
+            Voxel::new(4, 5, 6),
+            Voxel::new(7, 0, 1),
+        ];
+
+        let states = [1u8, 3u8, 4u8];
+
+        // Act
+        pallet.set(voxels[0], states[0]);
+        pallet.set(voxels[1], states[1]);
+        pallet.set(voxels[2], states[2]);
+
+        // Assert
+        assert_eq!(pallet.get(voxels[0]), states[0]);
+        assert_eq!(pallet.get(voxels[1]), states[1]);
+        assert_eq!(pallet.get(voxels[2]), states[2]);
+    }
+
+    #[test]
+    fn pallet_get_set_non_unique() {
+        // Arrange
+        let mut pallet = ChunkPack::new_pallet();
+
+        let voxels = [
+            Voxel::new(1, 2, 3),
+            Voxel::new(3, 5, 6),
+            Voxel::new(2, 5, 0),
+            Voxel::new(4, 6, 6),
+            Voxel::new(7, 0, 1),
+        ];
+
+        let states = [1u8, 2u8, 2u8, 4u8, 4u8];
+
+        // Act
+        for (idx, voxel) in voxels.into_iter().enumerate() {
+            pallet.set(voxel, states[idx]);
+        }
+
+        // Assert
+        for (idx, voxel) in voxels.into_iter().enumerate() {
+            assert_eq!(pallet.get(voxel), states[idx]);
+        }
+
+        match pallet {
+            // 3 new unique states + default state (air)
+            ChunkPack::Pallet { pallet, .. } => assert_eq!(pallet.len(), 4),
+            _ => unreachable!("Pallet was changed somewhere"),
+        }
+    }
+
+    #[test]
+    fn pallet_get_set_no_overflow() {
+        // Arrange
+        let mut pallet = ChunkPack::new_pallet();
+
+        // Act
+        for i in 0..u8::MAX as usize {
+            pallet.set(from_index(i), i as u8);
+        }
+
+        // Assert
+        for i in 0..u8::MAX as usize {
+            assert_eq!(pallet.get(from_index(i)), i as u8);
+        }
+
+        match pallet {
+            ChunkPack::Pallet { pallet, .. } => assert_eq!(pallet.len(), u8::MAX as usize),
+            _ => unreachable!("Pallet was changed somewhere"),
+        }
+    }
+
+    #[test]
+    fn pallet_get_set_no_overflow_with_dead_state() {
+        // Arrange
+        let mut pallet = ChunkPack::new_pallet();
+
+        // insert some dead states
+        match &mut pallet {
+            ChunkPack::Pallet { pallet, indices } => {
+                for i in 0u8..20 {
+                    pallet.pallet.push(1000 + i as u16);
+                }
+            }
+            _ => unreachable!(),
+        }
+
+        // Act
+        for i in 0..u8::MAX as usize {
+            pallet.set(from_index(i), i as u16);
+        }
+
+        // Assert
+        for i in 0..u8::MAX as usize {
+            assert_eq!(pallet.get(from_index(i)), i as u16);
+        }
+
+        match pallet {
+            ChunkPack::Pallet { pallet, .. } => assert_eq!(pallet.len(), u8::MAX as usize),
+            _ => unreachable!("Pallet was changed somewhere"),
+        }
+    }
+
+    #[test]
+    fn pallet_get_set_overflow() {
+        // Arrange
+        let mut pallet = ChunkPack::new_pallet();
+
+        // Act
+        for i in 0..BUFFER_SIZE {
+            pallet.set(from_index(i), i as u16);
+        }
+
+        // Assert
+        for i in 0..BUFFER_SIZE {
+            assert_eq!(pallet.get(from_index(i)), i as u16);
+        }
+
+        assert!(matches!(pallet, ChunkPack::Dense(_)));
+    }
+
+    #[test]
+    fn pallet_get_set_overflow_with_dead_states() {
+        // Arrange
+        let mut pallet = ChunkPack::new_pallet();
+
+        // insert some dead states
+        match &mut pallet {
+            ChunkPack::Pallet { pallet, indices } => {
+                for i in 0u8..20 {
+                    pallet.pallet.push(1000 + i as u16);
+                }
+            }
+            _ => unreachable!(),
+        }
+
+        // Act
+        for i in 0..BUFFER_SIZE {
+            pallet.set(from_index(i), i as u16);
+        }
+
+        // Assert
+        for i in 0..BUFFER_SIZE {
+            assert_eq!(pallet.get(from_index(i)), i as u16);
+        }
+
+        assert!(matches!(pallet, ChunkPack::Dense(_)));
+    }
+
+    #[test]
+    fn dense_get_set() {
+        // Arrange
+        let mut pack = ChunkPack::Dense(DenseBuffer(vec![Default::default(); BUFFER_SIZE]));
+        let state = 1u8;
+        let voxel = Voxel::new(1, 2, 3);
+
+        // Act
+        pack.set(voxel, state);
+
+        // Assert
+        assert_eq!(state, pack.get(voxel));
+    }
+
+    #[test]
+    fn pack_single() {
+        // Arrange
+        let state = 1u8;
+        let mut single = ChunkPack::Single(state);
+
+        // Act
+        single.pack();
+
+        // Assert
+        match single {
+            ChunkPack::Single(voxel_state) => assert_eq!(voxel_state, state),
+            _ => panic!("Calling pack on single value should never change it"),
+        }
+    }
+
+    #[test]
+    fn pack_pallet_with_one_unique() {
+        // Arrange
+        let state = 1u8;
+
+        let mut pallet = ChunkPack::Pallet {
+            pallet: VoxelStatePallet::new(vec![state]),
+            indices: PackIndices(vec![0; BUFFER_SIZE]),
+        };
+
+        // Act
+        pallet.pack();
+
+        // Assert
+        match pallet {
+            ChunkPack::Single(voxel_state) => assert_eq!(voxel_state, state),
+            _ => panic!("Calling pack on pallet with 1 unique value should return single"),
+        }
+    }
+
+    #[test]
+    fn pack_pallet_with_one_unique_with_dead_state() {
+        // Arrange
+        let state = 1u8;
+        let dead = 2u8;
+
+        let mut pallet = VoxelStatePallet::new(vec![state, dead]);
+        pallet.dirty = true;
+
+        let mut pallet = ChunkPack::Pallet {
+            pallet,
+            indices: PackIndices(vec![0; BUFFER_SIZE]),
+        };
+
+        // Act
+        pallet.pack();
+
+        // Assert
+        match pallet {
+            ChunkPack::Single(voxel_state) => assert_eq!(voxel_state, state),
+            _ => panic!("Calling pack on pallet with 1 unique value should return single"),
+        }
+    }
+
+    #[test]
+    fn pack_dense_unique() {
+        // Arrange
+        let mut voxels = DenseBuffer(vec![Default::default(); BUFFER_SIZE]);
+        for i in 0..BUFFER_SIZE {
+            voxels[i] = i as u16;
+        }
+
+        let mut dense = ChunkPack::Dense(voxels);
+        // Act
+        dense.pack();
+
+        // Assert
+        assert!(
+            matches!(dense, ChunkPack::Dense(_)),
+            "The pack is full of unique states, so there should be no change"
+        );
+        for i in 0..BUFFER_SIZE {
+            assert_eq!(dense.get(from_index(i)), i as u16);
+        }
+    }
+
+    #[test]
+    fn pack_dense_non_unique() {
+        // Arrange
+        let mut voxels = DenseBuffer(vec![Default::default(); BUFFER_SIZE]);
+        for i in 0..BUFFER_SIZE {
+            let v = (i % 255) as u8;
+            voxels[i] = v;
+        }
+
+        let mut dense = ChunkPack::Dense(voxels);
+
+        // Act
+        dense.pack();
+
+        // Assert
+        match &dense {
+            ChunkPack::Pallet { pallet, .. } => {
+                assert_eq!(pallet.len(), 255);
+            }
+            _ => unreachable!("This should be packed into a pallet"),
+        }
+
+        for i in 0..BUFFER_SIZE {
+            let v = (i % 255) as u8;
+            assert_eq!(dense.get(from_index(i)), v);
+        }
+    }
+}

--- a/crates/core/src/voxel/kind.rs
+++ b/crates/core/src/voxel/kind.rs
@@ -150,7 +150,7 @@ impl KindsDescs {
 /// Kind id reference.
 /// This function uses [`KindsDescs`] to determine how this kind should behave.
 /// May panic if current kind id doesn't exists on [`KindsDescs`].
-#[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Default, Deserialize, Serialize)]
+#[derive(Hash, Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Default, Deserialize, Serialize)]
 pub struct Kind(u16);
 
 impl From<u16> for Kind {

--- a/crates/core/src/voxel/kind.rs
+++ b/crates/core/src/voxel/kind.rs
@@ -86,11 +86,7 @@ impl KindsDescs {
 
     /// **Returns** how a given face should be rendered
     pub fn get_face_desc(&self, face: &Face) -> KindSideTexture {
-        let kind_desc = self
-            .descriptions
-            .iter()
-            .find(|k| k.id == face.kind.0)
-            .unwrap_or_else(|| panic!("Unable to find kind description for face {face:?}"));
+        let kind_desc = &self.descriptions[face.kind.0 as usize];
 
         match kind_desc.sides {
             KindSidesDesc::None => panic!("{} kind should not be rendered.", face.kind.0),
@@ -136,6 +132,7 @@ impl KindsDescs {
         match std::fs::File::open(&path) {
             Ok(file) => {
                 let kinds_descs: KindsDescs = ron::de::from_reader(file).unwrap();
+                check_descs(&kinds_descs);
                 KINDS_DESCS.set(kinds_descs).ok();
                 Self::get()
             }
@@ -145,6 +142,19 @@ impl KindsDescs {
             }
         }
     }
+}
+
+fn check_descs(kind_descs: &KindsDescs) {
+    kind_descs
+        .descriptions
+        .iter()
+        .enumerate()
+        .for_each(|(idx, item)| {
+            assert_eq!(
+                idx, item.id as usize,
+                "Item id and order doesn't match on kind description file!"
+            );
+        });
 }
 
 /// Kind id reference.

--- a/crates/core/src/voxel/mod.rs
+++ b/crates/core/src/voxel/mod.rs
@@ -119,6 +119,7 @@ impl Side {
         }
     }
 
+    #[inline]
     pub fn normal(&self) -> Vec3 {
         match self {
             Side::Right => Vec3::X,
@@ -307,7 +308,7 @@ pub fn to_world(voxel: IVec3, chunk: Chunk) -> Vec3 {
 
 #[cfg(test)]
 mod tests {
-    use rand::{random, Rng};
+    use rand::{Rng, random};
 
     use super::*;
 

--- a/crates/core/src/voxel/mod.rs
+++ b/crates/core/src/voxel/mod.rs
@@ -1,3 +1,5 @@
+use std::hash::Hash;
+
 use bevy::math::{IVec3, Vec2, Vec3};
 use serde::{Deserialize, Serialize};
 
@@ -37,7 +39,7 @@ impl LightTy {
 
 pub type Voxel = IVec3;
 
-#[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Default, Deserialize, Serialize)]
+#[derive(Hash, Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Default, Deserialize, Serialize)]
 pub struct Light(u8);
 
 impl Light {
@@ -159,7 +161,7 @@ impl Side {
     }
 }
 
-#[derive(Default, Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Deserialize, Serialize)]
+#[derive(Hash, Default, Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Deserialize, Serialize)]
 pub struct FacesOcclusion(u8);
 
 const FULL_OCCLUDED_MASK: u8 = 0b0011_1111;
@@ -221,24 +223,46 @@ impl ChunkFacesOcclusion {
 }
 
 /// Contains smoothed vertex light for each face
-#[derive(Default, Debug, Clone, Copy, PartialEq, PartialOrd, Serialize, Deserialize)]
-pub struct FacesSoftLight([[f32; 4]; SIDE_COUNT]);
+#[derive(Hash, Default, Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Serialize, Deserialize)]
+pub struct FacesSoftLight([u128; SIDE_COUNT]);
 
 impl FacesSoftLight {
     pub fn new(soft_light: [[f32; 4]; SIDE_COUNT]) -> Self {
-        Self(soft_light)
+        let mut buffer = [0u128; SIDE_COUNT];
+        for i in 0..SIDE_COUNT {
+            buffer[i] = Self::from_array_f32(soft_light[i]);
+        }
+        Self(buffer)
     }
 
     pub fn with_intensity(intensity: u8) -> Self {
-        Self([[intensity as f32; 4]; SIDE_COUNT])
+        Self::new([[intensity as f32; 4]; SIDE_COUNT])
     }
 
     pub fn set(&mut self, side: Side, light: [f32; 4]) {
-        self.0[side as usize] = light;
+        self.0[side as usize] = Self::from_array_f32(light);
     }
 
     pub fn get(&self, side: Side) -> [f32; 4] {
-        self.0[side as usize]
+        Self::to_array_f32(self.0[side as usize])
+    }
+
+    #[inline]
+    fn from_array_f32(array: [f32; 4]) -> u128 {
+        (array[0].to_bits() as u128) << 96
+            | (array[1].to_bits() as u128) << 64
+            | (array[2].to_bits() as u128) << 32
+            | array[3].to_bits() as u128
+    }
+
+    #[inline]
+    fn to_array_f32(bits: u128) -> [f32; 4] {
+        [
+            f32::from_bits(((bits >> 96) & 0xFFFF_FFFF) as u32),
+            f32::from_bits(((bits >> 64) & 0xFFFF_FFFF) as u32),
+            f32::from_bits(((bits >> 32) & 0xFFFF_FFFF) as u32),
+            f32::from_bits((bits & 0xFFFF_FFFF) as u32),
+        ]
     }
 }
 
@@ -307,6 +331,41 @@ mod tests {
         light.set(LightTy::Artificial, 4);
 
         assert_eq!(light.get_greater_intensity(), 4);
+    }
+
+    #[test]
+    fn faces_soft_light() {
+        let faces_soft_light = FacesSoftLight::with_intensity(15);
+
+        for side in SIDES {
+            assert_eq!(faces_soft_light.get(side), [15.0; 4]);
+        }
+
+        let faces_soft_light = FacesSoftLight::default();
+
+        for side in SIDES {
+            assert_eq!(faces_soft_light.get(side), [0.0; 4]);
+        }
+
+        let soft_light = [
+            [1.0, 2.0, 3.0, 4.0],
+            [5.0, 6.0, 7.0, 8.0],
+            [9.0, 10.0, 11.0, 12.0],
+            [13.0, 14.0, 15.0, 16.0],
+            [17.0, 18.0, 19.0, 20.0],
+            [21.0, 22.0, 23.0, 24.0],
+        ];
+
+        let mut faces_soft_light = FacesSoftLight::new(soft_light);
+
+        for (i, side) in SIDES.iter().enumerate() {
+            assert_eq!(faces_soft_light.get(*side), soft_light[i]);
+        }
+
+        let light = [25.0, 26.0, 27.0, 28.0];
+        faces_soft_light.set(Side::Up, light);
+
+        assert_eq!(faces_soft_light.get(Side::Up), light);
     }
 
     #[test]

--- a/crates/server/Cargo.toml
+++ b/crates/server/Cargo.toml
@@ -51,3 +51,7 @@ path = "bin/main.rs"
 [[example]]
 name = "server_bench"
 path = "examples/server_bench.rs"
+
+[[example]]
+name = "sample_chunks"
+path = "examples/sample_chunks.rs"

--- a/crates/server/Cargo.toml
+++ b/crates/server/Cargo.toml
@@ -39,7 +39,6 @@ bracket-noise = "0.8.7"
 rand.workspace = true
 tracing = "0.1"
 tracing-subscriber = "0.3"
-peak_alloc = "0.2"
 
 [lints]
 workspace = true

--- a/crates/server/Cargo.toml
+++ b/crates/server/Cargo.toml
@@ -39,6 +39,7 @@ bracket-noise = "0.8.7"
 rand.workspace = true
 tracing = "0.1"
 tracing-subscriber = "0.3"
+criterion = "0.7"
 
 [lints]
 workspace = true
@@ -54,3 +55,7 @@ path = "examples/server_bench.rs"
 [[example]]
 name = "sample_chunks"
 path = "examples/sample_chunks.rs"
+
+[[bench]]
+name = "meshing"
+harness = false

--- a/crates/server/benches/meshing.rs
+++ b/crates/server/benches/meshing.rs
@@ -16,8 +16,10 @@ pub fn criterion_benchmark(c: &mut Criterion) {
     println!("Occlusion: {occlusion:?}");
     println!("Soft Light: {soft_light:?}");
 
-    let vertices = generate_faces(&kind, &occlusion, &soft_light);
+    let faces = generate_faces(&kind, &occlusion, &soft_light);
+    let vertices = generate_vertices(&faces);
 
+    println!("Faces: {:?}", faces.len());
     println!("Vertices: {:?}", vertices.len());
 
     c.bench_function("generate faces", |b| {
@@ -28,7 +30,7 @@ pub fn criterion_benchmark(c: &mut Criterion) {
 
     c.bench_function("generate vertices", |b| {
         b.iter(|| {
-            std::hint::black_box(generate_vertices(&vertices));
+            std::hint::black_box(generate_vertices(&faces));
         });
     });
 }

--- a/crates/server/benches/meshing.rs
+++ b/crates/server/benches/meshing.rs
@@ -1,0 +1,39 @@
+use criterion::{criterion_group, criterion_main, Criterion};
+use projekto_server::{
+    meshing::{generate_faces, generate_vertices},
+    ChunkAsset,
+};
+
+pub fn criterion_benchmark(c: &mut Criterion) {
+    let ChunkAsset {
+        kind,
+        occlusion,
+        soft_light,
+        ..
+    } = setup();
+
+    let vertices = generate_faces(&kind, &occlusion, &soft_light);
+
+    c.bench_function("generate faces", |b| {
+        b.iter(|| {
+            std::hint::black_box(generate_faces(&kind, &occlusion, &soft_light));
+        });
+    });
+
+    c.bench_function("generate vertices", |b| {
+        b.iter(|| {
+            std::hint::black_box(generate_vertices(&vertices));
+        });
+    });
+}
+
+fn setup() -> ChunkAsset {
+    let path = std::path::Path::new("../../chunks/0_0");
+    let bytes = std::fs::read(path).unwrap();
+    let (asset, _) =
+        bincode::serde::decode_from_slice(&bytes, bincode::config::standard()).unwrap();
+    asset
+}
+
+criterion_group!(benches, criterion_benchmark);
+criterion_main!(benches);

--- a/crates/server/benches/meshing.rs
+++ b/crates/server/benches/meshing.rs
@@ -12,7 +12,13 @@ pub fn criterion_benchmark(c: &mut Criterion) {
         ..
     } = setup();
 
+    println!("Kind: {kind:?}");
+    println!("Occlusion: {occlusion:?}");
+    println!("Soft Light: {soft_light:?}");
+
     let vertices = generate_faces(&kind, &occlusion, &soft_light);
+
+    println!("Vertices: {:?}", vertices.len());
 
     c.bench_function("generate faces", |b| {
         b.iter(|| {

--- a/crates/server/examples/sample_chunks.rs
+++ b/crates/server/examples/sample_chunks.rs
@@ -1,0 +1,114 @@
+use std::time::Duration;
+
+use bevy::{app::ScheduleRunnerPlugin, log::LogPlugin, platform::collections::HashSet, prelude::*};
+use projekto_core::chunk;
+use projekto_server::{
+    bundle::{ChunkFacesOcclusion, ChunkFacesSoftLight, ChunkKind, ChunkLight},
+    set::Landscape,
+    WorldServerPlugin,
+};
+
+const TICK_EVERY_MILLIS: u64 = 50;
+
+fn main() {
+    let mut app = App::new();
+
+    app.add_plugins(LogPlugin::default());
+
+    // TODO: Rework this when plugins dependencies is a thing in bevy
+    projekto_server::setup_chunk_asset_loader(&mut app);
+
+    app.add_plugins((
+        AssetPlugin::default(),
+        MinimalPlugins.set(ScheduleRunnerPlugin::run_loop(Duration::from_millis(
+            TICK_EVERY_MILLIS,
+        ))),
+        WorldServerPlugin,
+    ))
+    .add_systems(Update, (set_landscape_once, count_chunk_states))
+    .run();
+}
+
+fn set_landscape_once(time: Res<Time>, mut commands: Commands, mut done: Local<bool>) {
+    if time.elapsed_secs() < 1.0 || *done {
+        return;
+    }
+
+    commands.insert_resource(Landscape {
+        center: IVec2::ZERO,
+        radius: 32,
+    });
+
+    *done = true;
+}
+
+fn count_chunk_states(
+    time: Res<Time>,
+    mut elapsed: Local<f64>,
+    q: Query<(
+        &ChunkKind,
+        &ChunkLight,
+        &ChunkFacesOcclusion,
+        &ChunkFacesSoftLight,
+    )>,
+) {
+    *elapsed += time.elapsed().as_secs_f64();
+
+    if *elapsed < 1.0 {
+        return;
+    }
+
+    *elapsed = 0.0;
+
+    if q.is_empty() {
+        info!("No chunks loaded yet!");
+        return;
+    }
+
+    let begin = std::time::Instant::now();
+
+    let mut data = vec![vec![]; 4];
+
+    for (kind, light, occlusion, soft_light) in q {
+        let unique_kinds = chunk::voxels().map(|v| kind.get(v)).collect::<HashSet<_>>();
+        let unique_lights = chunk::voxels()
+            .map(|v| light.get(v))
+            .collect::<HashSet<_>>();
+        let unique_occlusions = chunk::voxels()
+            .map(|v| occlusion.get(v))
+            .collect::<HashSet<_>>();
+        let unique_soft_lights = chunk::voxels()
+            .map(|v| soft_light.get(v))
+            .collect::<HashSet<_>>();
+
+        data[0].push(unique_kinds.len());
+        data[1].push(unique_lights.len());
+        data[2].push(unique_occlusions.len());
+        data[3].push(unique_soft_lights.len());
+    }
+
+    let statistics = calc_statistics(&data);
+    let duration = (std::time::Instant::now() - begin).as_millis();
+
+    info!("####################");
+    info!("####################");
+    info!("### Total: {}", data[0].len());
+    info!("### Kinds: {:?}", statistics[0]);
+    info!("### Lights: {:?}", statistics[1]);
+    info!("### Occlusions: {:?}", statistics[2]);
+    info!("### Soft Lights: {:?}", statistics[3]);
+    info!("####### {duration} #######");
+    info!("####################");
+}
+
+fn calc_statistics(data: &[Vec<usize>]) -> Vec<(usize, usize, usize)> {
+    data.iter()
+        .map(|metric| {
+            let count = metric.len();
+            let over = metric.iter().filter(|v| **v > 255).copied().count();
+            let max = metric.iter().copied().max().unwrap_or_default();
+            let sum = metric.iter().sum::<usize>();
+            (over, (sum / count), max)
+        })
+        .collect()
+}

--- a/crates/server/examples/sample_chunks.rs
+++ b/crates/server/examples/sample_chunks.rs
@@ -1,12 +1,7 @@
 use std::time::Duration;
 
-use bevy::{app::ScheduleRunnerPlugin, log::LogPlugin, platform::collections::HashSet, prelude::*};
-use projekto_core::chunk;
-use projekto_server::{
-    bundle::{ChunkFacesOcclusion, ChunkFacesSoftLight, ChunkKind, ChunkLight},
-    set::Landscape,
-    WorldServerPlugin,
-};
+use bevy::{app::ScheduleRunnerPlugin, log::LogPlugin, prelude::*};
+use projekto_server::{debug, set::Landscape, WorldServerPlugin};
 
 const TICK_EVERY_MILLIS: u64 = 50;
 
@@ -25,90 +20,26 @@ fn main() {
         ))),
         WorldServerPlugin,
     ))
-    .add_systems(Update, (set_landscape_once, count_chunk_states))
+    .add_systems(PostStartup, set_landscape)
+    .add_systems(PostUpdate, print_metrics)
     .run();
 }
 
-fn set_landscape_once(time: Res<Time>, mut commands: Commands, mut done: Local<bool>) {
-    if time.elapsed_secs() < 1.0 || *done {
-        return;
-    }
-
+fn set_landscape(mut commands: Commands) {
     commands.insert_resource(Landscape {
         center: IVec2::ZERO,
         radius: 32,
     });
-
-    *done = true;
 }
 
-fn count_chunk_states(
-    time: Res<Time>,
-    mut elapsed: Local<f64>,
-    q: Query<(
-        &ChunkKind,
-        &ChunkLight,
-        &ChunkFacesOcclusion,
-        &ChunkFacesSoftLight,
-    )>,
-) {
-    *elapsed += time.elapsed().as_secs_f64();
+fn print_metrics(time: Res<Time>, metrics: Res<debug::Metrics>, mut last_run: Local<f64>) {
+    *last_run += time.elapsed_secs_f64();
 
-    if *elapsed < 1.0 {
+    if *last_run < 5.0 {
         return;
     }
 
-    *elapsed = 0.0;
+    *last_run = 0.0;
 
-    if q.is_empty() {
-        info!("No chunks loaded yet!");
-        return;
-    }
-
-    let begin = std::time::Instant::now();
-
-    let mut data = vec![vec![]; 4];
-
-    for (kind, light, occlusion, soft_light) in q {
-        let unique_kinds = chunk::voxels().map(|v| kind.get(v)).collect::<HashSet<_>>();
-        let unique_lights = chunk::voxels()
-            .map(|v| light.get(v))
-            .collect::<HashSet<_>>();
-        let unique_occlusions = chunk::voxels()
-            .map(|v| occlusion.get(v))
-            .collect::<HashSet<_>>();
-        let unique_soft_lights = chunk::voxels()
-            .map(|v| soft_light.get(v))
-            .collect::<HashSet<_>>();
-
-        data[0].push(unique_kinds.len());
-        data[1].push(unique_lights.len());
-        data[2].push(unique_occlusions.len());
-        data[3].push(unique_soft_lights.len());
-    }
-
-    let statistics = calc_statistics(&data);
-    let duration = (std::time::Instant::now() - begin).as_millis();
-
-    info!("####################");
-    info!("####################");
-    info!("### Total: {}", data[0].len());
-    info!("### Kinds: {:?}", statistics[0]);
-    info!("### Lights: {:?}", statistics[1]);
-    info!("### Occlusions: {:?}", statistics[2]);
-    info!("### Soft Lights: {:?}", statistics[3]);
-    info!("####### {duration} #######");
-    info!("####################");
-}
-
-fn calc_statistics(data: &[Vec<usize>]) -> Vec<(usize, usize, usize)> {
-    data.iter()
-        .map(|metric| {
-            let count = metric.len();
-            let over = metric.iter().filter(|v| **v > 255).copied().count();
-            let max = metric.iter().copied().max().unwrap_or_default();
-            let sum = metric.iter().sum::<usize>();
-            (over, (sum / count), max)
-        })
-        .collect()
+    metrics.print();
 }

--- a/crates/server/src/debug.rs
+++ b/crates/server/src/debug.rs
@@ -1,0 +1,70 @@
+use std::time::Instant;
+
+use bevy::{platform::collections::HashMap, prelude::*};
+
+#[derive(Default)]
+pub struct MetricData {
+    name: &'static str,
+    runs: Vec<(Instant, Option<Instant>)>,
+}
+
+impl MetricData {
+    pub fn new(name: &'static str) -> Self {
+        Self { name, runs: vec![] }
+    }
+
+    pub fn begin(&mut self) {
+        self.runs.push((Instant::now(), None));
+    }
+
+    pub fn end(&mut self) {
+        let run = self.runs.last_mut().unwrap();
+        run.1 = Some(Instant::now());
+    }
+}
+
+#[derive(Resource, Default)]
+pub struct Metrics(HashMap<&'static str, MetricData>);
+
+impl Metrics {
+    pub fn new() -> Self {
+        Default::default()
+    }
+
+    pub fn add(&mut self, mut data: MetricData) {
+        if !data.runs.is_empty() {
+            self.0
+                .entry(data.name)
+                .or_insert(MetricData::new(data.name))
+                .runs
+                .append(&mut data.runs);
+        }
+    }
+
+    pub fn print(&self) {
+        for (_name, data) in &self.0 {
+            let runs = data.runs.len();
+
+            if runs == 0 {
+                continue;
+            }
+
+            let name = data.name;
+            let durations = data
+                .runs
+                .iter()
+                .filter(|r| r.1.is_some())
+                .map(|(b, e)| (e.unwrap() - *b).as_millis())
+                .collect::<Vec<_>>();
+
+            let min = durations.iter().min().copied().unwrap_or_default();
+            let max = durations.iter().max().copied().unwrap_or_default();
+            let sum = durations.iter().sum::<u128>();
+            let avg = sum / runs as u128;
+
+            debug!(
+                "[{name}] runs: {runs}, min: {min}ms, max: {max}ms, avg: {avg}ms, total: {sum}ms"
+            );
+        }
+    }
+}

--- a/crates/server/src/lib.rs
+++ b/crates/server/src/lib.rs
@@ -6,12 +6,13 @@ use net::NetPlugin;
 
 // pub mod app;
 mod light;
-mod meshing;
+pub mod meshing;
 
 mod asset;
 
 pub use asset::{setup_chunk_asset_loader, ChunkAsset, ChunkAssetHandle};
 
+pub mod debug;
 mod net;
 
 pub mod cache;
@@ -38,6 +39,7 @@ impl Plugin for WorldServerPlugin {
                     .chain(),
             )
             .configure_sets(PostUpdate, WorldSet::SendResponses)
+            .insert_resource(debug::Metrics::new())
             .add_plugins((
                 ChunkAssetPlugin,
                 NetPlugin,

--- a/crates/server/src/light.rs
+++ b/crates/server/src/light.rs
@@ -323,7 +323,7 @@ mod test {
         let _ = propagate(&kind, &mut light, LightTy::Natural, chunk::top_voxels());
 
         assert!(
-            light.all(|l| l.get(LightTy::Natural) == voxel::Light::MAX_NATURAL_INTENSITY),
+            light.all(|l| { l.get(LightTy::Natural) == voxel::Light::MAX_NATURAL_INTENSITY }),
             "All voxels should have full natural light propagated"
         );
     }

--- a/crates/server/src/meshing.rs
+++ b/crates/server/src/meshing.rs
@@ -46,7 +46,7 @@ pub const VERTICES_INDICES: [[usize; 4]; 6] = [
 /// All generated indices will be relative to a triangle list.
 ///
 /// **Returns** a list of generated [`voxel::Vertex`].
-pub(super) fn generate_vertices(faces: Vec<voxel::Face>) -> Vec<voxel::Vertex> {
+pub fn generate_vertices(faces: &[voxel::Face]) -> Vec<voxel::Vertex> {
     let mut vertices = vec![];
     let kinds_descs = voxel::KindsDescs::get();
     let tile_texture_size = (kinds_descs.count_tiles() as f32).recip();
@@ -147,7 +147,7 @@ pub(super) fn faces_occlusion(
     });
 }
 
-pub(super) fn generate_faces(
+pub fn generate_faces(
     kind: &ChunkStorage<voxel::Kind>,
     occlusion: &ChunkStorage<voxel::FacesOcclusion>,
     soft_light: &ChunkStorage<voxel::FacesSoftLight>,

--- a/crates/server/src/meshing.rs
+++ b/crates/server/src/meshing.rs
@@ -48,17 +48,23 @@ pub const VERTICES_INDICES: [[usize; 4]; 6] = [
 /// **Returns** a list of generated [`voxel::Vertex`].
 pub fn generate_vertices(faces: &[voxel::Face]) -> Vec<voxel::Vertex> {
     const VERTICES_ESTIMATION: usize = (chunk::BUFFER_SIZE * voxel::SIDE_COUNT * 6) / 2;
+    const LIGHT_FRACTION: f32 = (voxel::Light::MAX_NATURAL_INTENSITY as f32).recip();
+
+    #[inline]
+    fn calc_tile_size(min: Vec3, max: Vec3) -> f32 {
+        (min.x - max.x).abs() + (min.y - max.y).abs() + (min.z - max.z).abs()
+    }
 
     let mut vertices = Vec::with_capacity(VERTICES_ESTIMATION);
-
     let kinds_descs = voxel::KindsDescs::get();
-    let tile_texture_size = (kinds_descs.count_tiles() as f32).recip();
+
     let mut faces_vertices = [Vec3::ZERO; 4];
 
     for face in faces {
         let normal = face.side.normal();
 
         let face_desc = kinds_descs.get_face_desc(face);
+        let tile_texture_size = (kinds_descs.count_tiles() as f32).recip();
         let tile_coord_start = face_desc.offset.as_vec2() * tile_texture_size;
 
         for (i, v) in face.vertices.iter().enumerate() {
@@ -73,10 +79,6 @@ pub fn generate_vertices(faces: &[voxel::Face]) -> Vec<voxel::Vertex> {
             "Each face should have 4 vertices"
         );
 
-        fn calc_tile_size(min: Vec3, max: Vec3) -> f32 {
-            (min.x - max.x).abs() + (min.y - max.y).abs() + (min.z - max.z).abs()
-        }
-
         let x_tile = calc_tile_size(faces_vertices[0], faces_vertices[1]) * tile_texture_size;
         let y_tile = calc_tile_size(faces_vertices[0], faces_vertices[3]) * tile_texture_size;
 
@@ -87,15 +89,13 @@ pub fn generate_vertices(faces: &[voxel::Face]) -> Vec<voxel::Vertex> {
             (0.0, 0.0).into(),
         ];
 
-        let light_fraction = (voxel::Light::MAX_NATURAL_INTENSITY as f32).recip();
-
         for (i, v) in faces_vertices.iter().copied().enumerate() {
             vertices.push(voxel::Vertex {
                 position: v,
                 normal,
                 uv: tile_uv[i],
                 tile_coord_start,
-                light: Vec3::splat(face.light[i] * light_fraction),
+                light: Vec3::splat(face.light[i] * LIGHT_FRACTION),
             });
         }
     }

--- a/crates/server/src/set/chunk_management.rs
+++ b/crates/server/src/set/chunk_management.rs
@@ -94,12 +94,6 @@ fn chunks_spawn(
         };
 
         if loaded {
-            let maybe_asset = assets.remove(&handle.0);
-
-            if maybe_asset.is_none() {
-                panic!("Wat?")
-            }
-
             let ChunkAsset {
                 chunk,
                 kind,
@@ -107,7 +101,7 @@ fn chunks_spawn(
                 occlusion,
                 soft_light,
                 vertex,
-            } = maybe_asset.expect("Chunk asset exists");
+            } = assets.remove(&handle.0).expect("Chunk asset exists");
 
             let entity = commands
                 .spawn((

--- a/crates/server/src/set/chunk_management.rs
+++ b/crates/server/src/set/chunk_management.rs
@@ -94,6 +94,12 @@ fn chunks_spawn(
         };
 
         if loaded {
+            let maybe_asset = assets.remove(&handle.0);
+
+            if maybe_asset.is_none() {
+                panic!("Wat?")
+            }
+
             let ChunkAsset {
                 chunk,
                 kind,
@@ -101,7 +107,7 @@ fn chunks_spawn(
                 occlusion,
                 soft_light,
                 vertex,
-            } = assets.remove(&handle.0).expect("Chunk asset exists");
+            } = maybe_asset.expect("Chunk asset exists");
 
             let entity = commands
                 .spawn((

--- a/examples/orbit_cam.rs
+++ b/examples/orbit_cam.rs
@@ -1,7 +1,7 @@
 use bevy::prelude::*;
 use projekto_camera::{
-    orbit::{OrbitCamera, OrbitCameraConfig, OrbitCameraTarget},
     CameraPlugin,
+    orbit::{OrbitCamera, OrbitCameraConfig, OrbitCameraTarget},
 };
 
 fn main() {

--- a/examples/swap_cam.rs
+++ b/examples/swap_cam.rs
@@ -2,9 +2,9 @@ use std::marker::PhantomData;
 
 use bevy::{ecs::system::SystemParam, prelude::*, window::PrimaryWindow};
 use projekto_camera::{
+    CameraPlugin,
     fly_by::{FlyByCamera, FlyByCameraConfig},
     orbit::{OrbitCamera, OrbitCameraConfig, OrbitCameraTarget},
-    CameraPlugin,
 };
 
 fn main() {


### PR DESCRIPTION
Implemented the sub chunk strategy, where each chunk is sub divided into 8x8x8 chunks, which can be packed into single value or use a pallet. The size of 8x8x8 is because it can fit into a 1 byte index of the pallet, reducing the memory footprint.

If, somehow, there are more than 255 unique values in a single SubChunk, then a Dense variant is used, which is a just plain and old array.